### PR TITLE
doc: Fix 1.2 documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ All Documentation about the bootloader can be found in the doc folder:
 
 - `Bootloader resources <doc/boot_resources.rst>`__
 - `Bootloader flow      <doc/boot_flow.rst>`__
-- `DFU information      <doc/dfu.rst>`__
-- `FM information       <doc/fw-manager>`__
+- `Firmware Manager User Guide`_
+- `Firmware Manager Overview`_
 
 Building
 ********
@@ -98,7 +98,7 @@ variable must point to the QMSI folder, for instance:
 If such a variable is not defined, the bootloader expects QMSI folder to be
 named ``qmsi`` and be a sibling folder of the bootloader one.
 
-To use the "make flash" command ,the $QM_BOOTLOADER_DIR enviroment variable
+To use the "make flash" command ,the $QM_BOOTLOADER_DIR environment variable
 should be set.
 
 ``export QM_BOOTLOADER_DIR=$HOME/bootloader``
@@ -138,8 +138,8 @@ bootloader,
 
 By default, firmware management mode is not enabled.
 
-More info on building and flashing an application using the firmware managment
-mode can be found in the `fw-manager-user-guide <doc/fw-manager-user-guide.rst>`__
+More info on building and flashing an application using the firmware management
+mode can be found in the `Firmware Manager User Guide`_.
 
 Flashing
 ========
@@ -147,7 +147,7 @@ Flashing
 The bootloader must be flashed on the OTP ROM flash region.
 
 For flashing the board OpenOCD must be used. You can optionally use gdb
-as a frontend for OpenOCD as described below.
+as a front-end for OpenOCD as described below.
 
 Assuming the toolchain was unpacked into *$HOME/issm_2016/*, this can be
 done with:
@@ -162,8 +162,8 @@ For SE C1000, start OpenOCD with the following command:
 
 ``$ ./bin/openocd -f scripts/board/quark_se_onboard.cfg``
 
-Create a new terminal session at this point and set environment variables accordingly.
-Then launch a GDB session using:
+Create a new terminal session at this point and set environment variables
+accordingly.  Then launch a GDB session using:
 
 ``$ gdb``
 
@@ -178,9 +178,12 @@ For D2000, the following command is used to flash the bootloader to the device:
 ``(gdb) monitor load_image $PATH_TO_QM_BOOTLOADER/build/release/quark_d2000/rom/quark_d2000_rom.bin 0x0``
 
 
-For SE C1000, the following command is used to flash the bootloader to the device:
+For SE C1000, the following command is used to flash the bootloader to the
+device:
 
 ``(gdb) monitor load_image $PATH_TO_QM_BOOTLOADER/build/release/quark_se/rom/quark_se_rom.bin 0xFFFFE000``
 
-Change Log
-**********
+
+.. Links
+.. _`Firmware Manager User Guide`: doc/fw-manager-user-guide.rst
+.. _`Firmware Manager Overview`: doc/fw-manager-overview.rst

--- a/doc/boot_flow.rst
+++ b/doc/boot_flow.rst
@@ -1,16 +1,16 @@
 BOOTLOADER FLOW
 ###############
 
-This document describes the flow of the bootloader, from hw boot to the start
-of the application.
+This document describes the flow of the bootloader, from hardware boot to the
+start of the application.
 
-The bootloader has some dedicated resources, these are described in the
-`resources document <../boot_resources.rst>`_.
+The bootloader has some dedicated resources, they are described in the
+`Bootloader Resources document <boot_resources.rst>`_.
 
 FLOW
 ****
 
-#. Assembly start-up:
+#. Initialize x86 core:
      - Invalidate cache [Quark SE only].
      - Store Built-in-Self-Test (BIST) value in EBP.
      - Load the GDT table into the descriptor.
@@ -21,14 +21,13 @@ FLOW
      - Stack pointer set-up
      - RAM set-up
      - Power set-up
-     - Clock set-up:
-       Check if the trim codes are stored in flash. Compute trim code
-       and store them in flash if no trim codes were found.
+     - Clock set-up: check if trim codes are stored in flash; compute trim
+       codes and store them in flash if no trim codes were found.
 
 #. JTAG probe hook:
-     - The bootloader checks if the JTAG_PROBE_PIN is asserted (grounded). It
-       will continue once the pin is de-asserted(ungrounded). This is used to
-       unbrick a device with firmware that is preventing JTAG from working
+     - The bootloader checks if the JTAG_PROBE_PIN is asserted (grounded) and,
+       if so, it waits until the pin is de-asserted (ungrounded). This is used
+       to unbrick a device with firmware that is preventing JTAG from working
        correctly.
 
 #. Set-up secondary peripherals:
@@ -36,29 +35,22 @@ FLOW
      #. IDT set-up
      #. Set-up interrupt controller
 
-#. Configure flash controller(s): [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
+#. Configure flash controller(s): [Compile option: ``ENABLE_FIRMWARE_MANAGER=[uart|2nd-stage]``]
      - Configure flash partition 0.
      - Configure flash partition 1 if the SoC is Quark SE.
 
-#. Sanitize bootloader data: [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
+#. Sanitize bootloader data: [Compile option: ``ENABLE_FIRMWARE_MANAGER=[uart|2nd-stage]``]
      - The bootloader checks if the meta-data partitions are not corrupted and
-       fixes them if need.
+       fixes them if needed.
 
-#. Firmware management(FM): [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
-     - The bootloader goes into Firmware management mode if the FM enable pin
-       is asserted (grounded) or when sticky register ``GPS0`` is set.
+#. Start Firmware Manager: [Compile option: ``ENABLE_FIRMWARE_MANAGER=[uart|2nd-stage]``]
+     - The bootloader goes into Firmware Management (FM) mode if the FM pin is
+       asserted (grounded) or the FM sticky bit is set.
 
-#. Start the application:
-     - Start x86 application if present (the first double word is different
+#. Start x86 application:
+     - Start the x86 application if present (the first double word is different
        from 0xffffffff).
 
 #. Sleep:
-      - When the x86 application returns, the bootloader performs different
-        actions depending on the SoC.
-
-      Quark D2000:
-        * The SoC goes into deep sleep mode.
-
-      Quark SE:
-        * The x86 core is halted (C2 power state).
-        * No special action is performed for the sensor core.
+      - When the x86 application returns, the bootloader halts the x86 core
+        (while leaving the state of the Sensor Subsystem unmodified).

--- a/doc/boot_resources.rst
+++ b/doc/boot_resources.rst
@@ -5,8 +5,8 @@ BOOTLOADER RESOURCES
 
 The bootloader uses dedicated resources to guarantee its flow. Hardware
 designers and application developers should pay attention how they use the
-resources to avoid unexpected behavior. The bootloader will not use the
-resources with a compile option if they are not set.
+resources to avoid unexpected behavior. The bootloader will not use resources
+associated with a specific compile option if such an option is not set.
 
 Overview
 --------
@@ -19,9 +19,9 @@ Overview
 +------------------+---------------+----------------+------------------+
 | JTAG probe       | GPIO_13       | GPI0_15        | Do not ground    |
 +------------------+---------------+----------------+------------------+
-| Sleep register   | N/A           | GPS1           | Reserved         |
+| UART port        | Uart 0        | Uart 1         | Available to app |
 +------------------+---------------+----------------+------------------+
-| UART PORT        | Uart 0        | Uart 1         | Available to app |
+| USB controller   | n/a           | USB 0          | Available to app |
 +------------------+---------------+----------------+------------------+
 | FM register      | GPS0 bit 0    | GPS0 bit 0     | Reserved         |
 +------------------+---------------+----------------+------------------+
@@ -35,52 +35,55 @@ Gpio pins
 The bootloader uses the following pins:
 
 * JTAG probe pin:
-        - Quark SE C1000:       ``GPIO_15``
-        - Quark D2000:          ``GPIO_13``
+    - Quark SE C1000:       ``GPIO_15``
+    - Quark D2000:          ``GPIO_13``
 
-        This pin is used to put the bootloader into unbrick mode. Unbrick mode
-        can be used when the JTAG is not able to connect to the device during
-        runtime.
+  This pin is used to put the bootloader into recovery mode. Recovery mode can
+  be used when the JTAG is not able to connect to the device during runtime.
 
-* Firmware management pin:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
-        - Quark SE C1000:       ``AON 0``
-        - Quark D2000:    ``GPIO_2``
+* FM pin:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=[uart|2nd-stage]``]
+    - Quark SE C1000:       ``AON 0``
+    - Quark D2000:    ``GPIO_2``
 
-        This pin is used to start the bootloader in the firmware management mode
-        (FM).
+  This pin is used to start the bootloader in the Firmware Management (FM)
+  mode.
 
-**Gpio pins used by the bootloader should not be grounded during the boot process!**
+**GPIO pins used by the bootloader should not be grounded during the boot
+process.**
 
 Sticky registers
 ****************
 
 The bootloader uses the following sticky registers:
 
-* Firmware manager:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
-        - All SoC's:    ``GPS0 bit 0``
+* FM sticky bit:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=[uart|2nd-stage]``]
+    - All SoC's:    ``GPS0 bit 0``
 
-        This register is used to start the bootloader in the firmware management
-        mode (FM). **This bit is reserved for the bootloader, the application
-        should not use this bit!**
+  This register is used to start the bootloader in Firmware Management (FM)
+  mode. **This bit is reserved for the bootloader, the application should not
+  use it.**
 
 Peripherals
 ***********
 
 The following peripherals are used by the bootloader:
 
-* Firmware manager:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=1``]
-        - Quark Se C1000:       ``Uart1``
-        - Quark D2000:          ``Uart0``
+* FM UART:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=uart``]
+    - Quark Se C1000:       ``UART1``
+    - Quark D2000:          ``UART0``
 
-The uart will be used to program the device by the Firmware manager. The
-uart can be freely used by the application.
+* FM USB:  [Compile option: ``ENABLE_FIRMWARE_MANAGER=2nd-stage`` (and 2nd-stage bootloader programmed)]
+    - Quark Se C1000:       ``USB0``
+    - Quark D2000:          n/a
+
+Both the FM UART and USB can be freely used by the application.
 
 Time constraints
 ****************
 
 The bootloader guarantees a boot-time smaller than 10ms during normal boot.
-The boot time could increase during the first boot or when the Firmware
-management session is active.
+The boot time could increase during the first boot or after a Firmware
+Management session.
 
 Flash
 *****
@@ -88,9 +91,9 @@ Flash
 A part of the flash of the device is reserved for the bootloader data (BL-data).
 
 +------------------+--------------------------+-------+----------------+
-| SoC              | BL-data                  | Size  | Flash region   |
+| SoC              | Address range            | Size  | Flash region   |
 +==================+==========================+=======+================+
-| Quark D2000      | 0x00200000 - 0x00201000  | 4096  | Data           |
+| Quark D2000      | 0x00200000 - 0x00201000  | 4kB   | Data           |
 +------------------+--------------------------+-------+----------------+
-| Quark SE C1000   | 0x4002F000 - 0x40030000  | 4096  | System flash 0 |
+| Quark SE C1000   | 0x4002F000 - 0x40030000  | 4kB   | System flash 0 |
 +------------------+--------------------------+-------+----------------+

--- a/doc/fw-manager-overview.rst
+++ b/doc/fw-manager-overview.rst
@@ -6,40 +6,39 @@ Quark Firmware Management
 Overview
 ********
 
-The fw-manager module of the Quark Bootloader enables the firmware
-management mode, an alternative mode to the normal operation mode whereby the
-device is ready to serve system management requests from an external Host. For
-the whole duration of the Firmware Management mode, the MCU does not run its
-application and only serves management requests from an external host.
+The *fw-manager* module of the Quark Bootloader enables the Firmware Management
+(FM) mode, an alternative mode to the normal operation mode whereby the device
+is ready to serve system management requests from an external host.  For the
+whole duration of FM mode, the MCU does not run its application and only serves
+management requests from an external host.
 
-The firmware management mode provides the following services to the users:
+FM mode provides the following services to the users:
 
 * System information retrieval (SoC type, application version, security
   capability, etc.)
 * Application firmware update
 * Application firmware erase (erase of all the application code in flash)
 
-The MCU enters the FM mode only after an explicit request from the host. The
+The MCU enters FM mode only after an explicit request from the host. The
 mechanism used by the host to signal an Enter-FM request to the device depends
 on the specific communication link used for firmware management. In case of UART
 the host (or the user) must ground a specific pin and reset the device manually.
 
 A special case is when there is no application running on the device (i.e.,
-there is not any valid application firmware). In such a case, the bootloader
-puts the device into sleep mode.
+there is no valid application firmware). In such a case, the bootloader puts
+the device into sleep mode.
 
-When the host has completed its firmware management tasks, it can make the device
-exit FM mode by issuing a reset request. The device reboots and enter
+When the host has completed its firmware management tasks, it can make the
+device exit FM mode by issuing a reset request. The device reboots and enters
 application mode or sleep mode if no application is present.
 
 Protocol stack
 **************
 
-Even if the FM functionality is currently available via UART only, it has been
-designed to support different kinds of communication link. To this end, a
-single common protocol stack for performing FM operations has been defined. The
-core of such a stack is the (USB) `DFU protocol`_, a standard for
-performing firmware upgrades on USB devices.
+FM functionality has been designed to support different kinds of communication
+links. To this end, a single common protocol stack for performing FM operations
+has been defined. The core of such a stack is the (USB) `DFU protocol`_, a
+standard for performing firmware upgrades on USB devices.
 
 In order to use DFU also on UART (and other non-USB transports), a generic
 adaptation layer for non USB-transports, the *Quark DFU Adaptation (QDA)
@@ -53,22 +52,22 @@ can support authentication while maintaining compatibility with plain DFU
 (i.e., a signed firmware can potentially be downloaded and authenticated by the
 device using any standard DFU tool).
 
-The proposed FM protocol stack is the following.
+The current FM protocol stack is the following.
 
-+-----------------+-------------------+-------------+------------+
-|   Layer         |        USB        |     UART    |    SPI     |
-+=================+===================+=============+============+
-| **DFU payload** |           QFM Protocol / QFU Image           |
-+-----------------+-------------------+--------------------------+
-| **DFU flavor**  |      USB/DFU      |             QDA          |
-+-----------------+-------------------+--------------------------+
-| **Transport**   |        USB        |         XMODEM-CRC       |
-+-----------------+-------------------+-------------+------------+
-| **Driver**      | USB Device Driver | UART driver | SPI driver |
-+-----------------+-------------------+-------------+------------+
++-----------------+-------------------+-------------+
+|   Layer         |        USB        |     UART    |
++=================+===================+=============+
+| **DFU payload** |    QFM Protocol / QFU Image     |
++-----------------+-------------------+-------------+
+| **DFU flavor**  |      USB/DFU      |    QDA      |
++-----------------+-------------------+-------------+
+| **Transport**   |        USB        | XMODEM-CRC  |
++-----------------+-------------------+-------------+
+| **Driver**      | USB Device Driver | UART driver |
++-----------------+-------------------+-------------+
 
-As shown in the table, on top of UART and SPI we also use XMODEM-CRC_,
-in order to provide QDA with a reliable packet-based transport layer.
+As shown in the table, XMODEM-CRC_ is used on top of UART. The reason is to
+provide QDA with a reliable packet-based transport layer.
 
 USB/DFU
 =======

--- a/doc/fw-manager-user-guide.rst
+++ b/doc/fw-manager-user-guide.rst
@@ -6,7 +6,8 @@ Bootloader: Firmware Managment User Guide
 Overview
 ********
 
-The Intel® Quark™ supports DFU over the following connections:
+The Intel® Quark™ supports Firmware Management (FM) over the following
+connections:
 
 - SE C1000  USB         Linux/Windows
 - SE C1000  UART        Linux/Windows
@@ -25,8 +26,8 @@ The hardware setup consists of two main steps:
 The FM GPIO pin is the pin used to put the device into FM mode. The device has
 to be reset while the GPIO is connected to ground.
 
-Read the `resources documentation <doc/boot_resources.rst>`__ for more
-information on the hw set-up.
+Read the `resources documentation <boot_resources.rst>`__ for more
+information on the hardware set-up.
 
 
 FM GPIO pins
@@ -49,35 +50,32 @@ Software Setup
 Installing dfu-util
 ===================
 
-A different version of dfu-util must be used depending on the used connection.
+A different variant of dfu-util must be used depending on the used connection.
 
 Installing UART version
 -----------------------
 
-Dfu-util-qda is the tool needed to flash QFU images over UART to the target or
-manage the device.
-You can get the software from https://github.com/quark-mcu/qm-dfu-util, follow
-the building instructions in the `readme file <README.rst>`__.
+*dfu-util-qda* is the tool needed to flash QFU images over UART to the target
+or manage the device.  You can get the software from
+https://github.com/quark-mcu/qm-dfu-util, follow the building instructions in
+the `readme file
+<https://github.com/quark-mcu/qm-dfu-util/blob/master/README.rst>`__.
 
 Installing USB version
 ----------------------
 
-Dfu-util is the tool needed to flash QFU images over USB to the target or
+*dfu-util* is the tool needed to flash QFU images over USB to the target or
 manage the device.
 
-* On debian and Ubuntu systems you can install dfu-util by typing:
-
-::
+* On Debian and Ubuntu systems you can install dfu-util by typing::
 
     sudo apt-get install dfu-util
 
-* On fedora the command line command to install dfu-util is:
-
-::
+* On Fedora the command line command to install dfu-util is::
 
     sudo dnf install dfu-util
 
-Dfu-util can be installed manually. Please follow the instructions on
+dfu-util can also be installed manually. Please follow the instructions on
 http://dfu-util.sourceforge.net/.
 
 Enabling FM functionality in the bootloader
@@ -88,11 +86,9 @@ platform, you must install a ROM with such functionality enabled. To do so,
 perform the following steps:
 
 * Get the latest TinyCrypt code from https://github.com/01org/tinycrypt.
-* Checkout tag v0.2.0 and export the following environment variable:
+* Checkout tag v0.2.0 and export the following environment variable::
 
-::
-
-       export TINYCRYPT_SRC_DIR=/PATH/TO/SOURCE/tinycrypt
+    export TINYCRYPT_SRC_DIR=/PATH/TO/SOURCE/tinycrypt
 
 .. warning:: It is highly recommended to perform a flash mass erase before
              flashing the rom.
@@ -102,17 +98,13 @@ Enabling UART functionality
 
 * Compile the ROM code:
 
-  Enable the Firmware Manager for UART:
+  Enable the Firmware Manager for UART::
 
-  ::
+    make rom SOC=quark_se ENABLE_FIRMWARE_MANAGER=uart
 
-         make rom SOC=quark_se ENABLE_FIRMWARE_MANAGER=uart
+* Flash the new rom image to the target::
 
-* Flash the new rom image to the target:
-
-::
-
-       python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -r quarkse_dev ./build/release/quark_se/rom/quark_se_rom_fm.bin
+    python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -r quarkse_dev ./build/release/quark_se/rom/quark_se_rom_fm.bin
 
 Enabling USB functionality
 --------------------------
@@ -121,29 +113,21 @@ A second stage bootloader is required, in order to use the USB dfu-util.
 
 * Compile the ROM code:
 
-  Enable the second stage bootloader:
+  Enable the second stage bootloader::
 
-  ::
+    make rom SOC=quark_se ENABLE_FIRMWARE_MANAGER=2nd-stage
 
-         make rom SOC=quark_se ENABLE_FIRMWARE_MANAGER=2nd-stage
+* Flash the new rom image to the target::
 
-* Flash the new rom image to the target:
+    python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -r quarkse_dev ./build/release/quark_se/rom/quark_se_rom_fm_2nd_stage.bin
 
-::
+* Compile the 2nd stage bootloader::
 
-       python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -r quarkse_dev ./build/release/quark_se/rom/quark_se_rom_fm_2nd_stage.bin
+    make -C 2nd-stage
 
-* Compile the 2nd stage bootloader:
+* Flash the 2nd stage bootloder to address `0x4005b000`::
 
-::
-
-       make -C 2nd-stage
-
-* Flash the 2nd stage bootloder to address `0x4005b000`:
-
-::
-
-       python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -u quarkse_dev ./2nd-stage/release/quark_se/x86/bin/2nd_stage_usb.bin
+    python $(QMSI_SRC_DIR)/tools/jflash/jflash.py -u quarkse_dev ./2nd-stage/release/quark_se/x86/bin/2nd_stage_usb.bin
 
 FM functionality usage
 **********************
@@ -156,158 +140,130 @@ Simple way (using 'make flash')
 
 * Reset the device while connecting the FM GPIO to ground.
 * Compile, upload and run the example app.
-* Change to the QMSI directory.
+* Change to the QMSI directory::
 
-   ::
+    cd <PATH_TO_QMSI>
 
-         cd <PATH_TO_QMSI>
+  - For the UART connection::
 
-  - For the UART connection:
+      make -C <APP_DIR> flash SOC=<SOC> TARGET=<TARGET> SERIAL_PORT=<SERIAL_INTERFACE>
 
-  ::
+  - For the USB connection::
 
-         make -C <APP_DIR> flash SOC=<SOC> TARGET=<TARGET> SERIAL_PORT=<SERIAL_INTERFACE>
+      make -C <APP_DIR> flash SOC=<SOC> TARGET=<TARGET> USB_DEVICE=<VENDOR_ID:PRODUCT_ID>
 
-  - For the USB connection:
-
-  ::
-
-         make -C <APP_DIR> flash SOC=<SOC> TARGET=<TARGET> USB_DEVICE=<VENDOR:PRODUCT>
-
-The soc can be quark_se or quark_d2000 depending on the used soc. The target can
-be x86 or sensor depending on the used core.
+The SoC can be ``quark_se`` or ``quark_d2000`` depending on the used soc. The
+target can be ``x86`` or ``sensor`` depending on the used core.
 
 
 Make flash example
 ++++++++++++++++++
 
-The example will show how to build and flash the blinky example for the
-Quark SE C1000 x86 core. /dev/tty0 will be used as the connected uart.
+This example will show how to build and flash the blinky example for the
+Quark SE C1000 x86 core. For UART, the used serial device is assumed to be
+``/dev/tty0``; while for USB, the device Vendor ID and Product ID are assumed
+to be ``8086`` and ``48FC`` respectively.
 
-* Chance the directory to the QMSI base directory:
+* Change the directory to the QMSI base directory::
 
-  ::
+    cd $QMSI_SRC_DIR
 
-        cd $QMSI_SRC_DIR
+- For the UART connection::
 
-- For the UART connection:
+    make -C examples/blinky flash SOC=quark_se TARGET=x86 SERIAL_PORT=/dev/tty0
 
-  ::
+- For the USB connection::
 
-        make -C examples/blinky flash SOC=quark_se TARGET=x86 SERIAL_PORT=/dev/tty0
-
-- For the USB connection:
-
-  ::
-
-         make -C examples/blinky flash SOC=quark_se TARGET=x86 USB_DEVICE=<8086:48FC>
+    make -C examples/blinky flash SOC=quark_se TARGET=x86 USB_DEVICE=<8086:48FC>
 
 Step by step process (without make flash)
 -----------------------------------------
 
 
-* Change to the QMSI directory.
+* Change to the QMSI directory::
 
-   ::
+    cd <PATH_TO_QMSI>
 
-         cd <PATH_TO_QMSI>
+* Build the project::
 
-* Build the project:
-
-::
-
-       make -C <APP_DIR> SOC=<SOC> TARGET=<TARGET>
+    make -C <APP_DIR> SOC=<SOC> TARGET=<TARGET>
 
 The soc can be quark_se or quark_d2000 depending on the used soc. The target can
 be x86 or sensor depending on the used core.
 
-* Create the dfu file:
+* Create the dfu file::
 
-::
+    python ./tools/sysupdate/qm_make_dfu.py -v <BINARY_FILE> -p <PARTITION>
 
-       python ./tools/sysupdate/qm_make_dfu.py -v <BINARY_FILE> -p <PARTITION>
+The ``-p`` parameter is used to choose the flash partition. Partition 1 is used
+by the x86 core and partition 2 is used by the Sensor Subsystem.
 
-The -p parameter is used to choose the flash partition. Partition 1 is used by
-the x86 core and partition 2 is used by the Sensor subsystem.
--v will output some information about the generated image>
+The ``-v`` option makes the tool output some information about the generated
+image.
 
-The output DFU image will have the same name of the binary file with the '.dfu'
-extension appended.
+The output DFU image will have the same name of the binary file with the
+``.dfu`` extension appended.
 
 * Reset the device while connecting the FM GPIO to ground.
 * Download the image.
 
-  - Using a  UART connection:
+  - Using a  UART connection::
 
-  ::
+      dfu-util-qda -D <DFU_IMAGE> -p <SERIAL_INTERFACE> -R -a <PARTITION>
 
-         dfu-util-qda -D <DFU_IMAGE> -p <SERIAL_INTERFACE> -R -a <PARTITION>
+  - Using a USB connection::
 
-  - Using a USB connection:
+      dfu-util -D <DFU_IMAGE> -d <VENDOR_ID:PRODUCT_ID> -R -a <PARTITION>
 
-  ::
+The ``-a`` parameter is used to choose the flash partition. Partition 1 is used
+by the x86 core and partition 2 is used by the Sensor Subsystem.
 
-         dfu-util -D <DFU_IMAGE> -d <VENDOR:PRODUCT> -R -a <PARTITION>
-
-The -a parameter is used to choose the flash partition. Partition 1 is used by
-the x86 core and partition 2 is used by the Sensor subsystem.
-
-The -R parameter will reset the device after the download is finished.
+The ``-R`` parameter will reset the device after the download is finished.
 
 Step by step example
 ++++++++++++++++++++
 
-The example will show how to build and flash the blinky example for the
-Quark SE C1000 x86 core. /dev/tty0 will be used as the connected uart.
+This example will show how to build and flash the blinky example for the Quark
+SE C1000 x86 core.  For UART, the used serial device is assumed to be
+``/dev/tty0``; while for USB, the device Vendor ID and Product ID are assumed
+to be ``8086`` and ``48FC`` respectively.
 
-* Chance the directory to the QMSI base directory:
+* Change the directory to the QMSI base directory::
 
-::
+    cd $QMSI_SRC_DIR
 
-        cd $QMSI_SRC_DIR
+* Build the project::
 
-* Build the project:
+    make -C examples/blinky SOC=quark_se TARGET=x86
 
-::
+* Create the dfu file::
 
-       make -C examples/blinky SOC=quark_se TARGET=x86
+    python ./tools/sysupdate/qm_make_dfu.py -v examples/blinky/release/quark_se/x86/bin/blinky.bin -p 1
 
-* Create the dfu file:
+* You should get the following output if you add -v as a parameter::
 
-::
+    qm_make_dfu.py: QFU-Header and DFU-Suffix content:
+          Partition:   1
+          Vendor ID:   0
+          Product ID:  0
+          Version:     0
+          Block Size:  2048
+          Blocks:      2
+          DFU CRC:     0x8741e6e7
+    qm_make_dfu.py: blinky.dfu written
 
-       python ./tools/sysupdate/qm_make_dfu.py -v examples/blinky/release/quark_se/x86/bin/blinky.bin -p 1
-
-* You should get the following output if you add -v as a parameter:
-
-::
-
-      qm_make_dfu.py: QFU-Header and DFU-Suffix content:
-            Partition:   1
-            Vendor ID:   0
-            Product ID:  0
-            Version:     0
-            Block Size:  2048
-            Blocks:      2
-            DFU CRC:     0x8741e6e7
-      qm_make_dfu.py: blinky.dfu written
-
-blinky.dfu is your generated QFU image.
+``blinky.dfu`` is your generated QFU image.
 
 * Reset the device while connecting the FM GPIO to ground.
 * Download the image.
 
-  - Using a  UART connection:
+  - Using a  UART connection::
 
-  ::
+      dfu-util-qda -D examples/blinky/release/quark_se/x86/bin/blinky.bin.dfu -p /dev/tty0 -R -a 1
 
-         dfu-util-qda -D examples/blinky/release/quark_se/x86/bin/blinky.bin.dfu -p /dev/tty0 -R -a 1
+  - Using a USB connection::
 
-  - Using a USB connection:
-
-  ::
-
-         dfu-util -D examples/blinky/release/quark_se/x86/bin/blinky.bin.dfu -d <8086:48FC> -R -a 1
+      dfu-util -D examples/blinky/release/quark_se/x86/bin/blinky.bin.dfu -d <8086:48FC> -R -a 1
 
 
 .. note:: The path of the binary may differ when building a D2000 or a
@@ -330,17 +286,13 @@ Erase Applications
 * Enter device DFU mode by resetting the device while the FM GPIO is connected
   to ground:
 
-  - Run the following command for the UART connection:
+  - Run the following command for the UART connection::
 
-  ::
+      qm_manage.py erase -p <SERIAL_INTERFACE>
 
-         qm_manage.py erase -p <SERIAL_INTERFACE>
+  - Run the following command for the USB connection::
 
-  - Run the following command for the USB connection:
-
-  ::
-
-         qm_manage.py erase -d <VENDOR:PRODUCT>
+      qm_manage.py erase -d <VENDOR_ID:PRODUCT_ID>
 
 
 .. note:: All applications except the bootloader will be erased.
@@ -351,17 +303,14 @@ System Information
 * Enter device DFU mode by resetting the device while the FM GPIO is connected
   to ground:
 
-  * Run the following command for the UART connection:
+  * Run the following command for the UART connection::
 
-  ::
+     qm_manage.py info -p <SERIAL_INTERFACE>
 
-         qm_manage.py info -p <SERIAL_INTERFACE>
+  * Run the following command for the USB connection::
 
-  * Run the following command for the USB connection:
-
-  ::
-
-         qm_manage.py info -d <VENDOR:PRODUCT>
+     qm_manage.py info -d <VENDOR_ID:PRODUCT_ID>
 
 
-.. note:: By specifying `--format` the output format can be set. (text or json)
+.. note:: By specifying the ``--format`` parament, the output format can be set
+          to either text (default) or json.


### PR DESCRIPTION
This patch fixes a few inaccuracies, typos, formatting issues and broken
links in the documentation published with 1.2.0 release.

Signed-off-by: Daniele Alessandrelli daniele.alessandrelli@intel.com
